### PR TITLE
fixes to python version, data folder path and torch version

### DIFF
--- a/notebooks/use-pytorch-to-predict-handwritten-digits.ipynb
+++ b/notebooks/use-pytorch-to-predict-handwritten-digits.ipynb
@@ -308,7 +308,7 @@
    "outputs": [],
    "source": [
     "#Install PyTorch\n",
-    "!pip install http://download.pytorch.org/whl/cpu/torch-0.4.1-cp35-cp35m-linux_x86_64.whl\n",
+    "!pip install http://download.pytorch.org/whl/cpu/torch-0.4.0-cp35-cp35m-linux_x86_64.whl\n",
     "#Install torchvision\n",
     "!pip install torchvision"
    ]
@@ -354,7 +354,7 @@
     "import glob\n",
     "import os\n",
     "\n",
-    "files_search = os.path.join(data_dir, \"processed\", \"*\")\n",
+    "files_search = os.path.join(data_dir, \"MNIST/processed\", \"*\")\n",
     "files = glob.glob(files_search)\n",
     "\n",
     "bucket_obj = cos.Bucket(buckets[0])\n",
@@ -573,7 +573,7 @@
     "            client.repository.DefinitionMetaNames.FRAMEWORK_NAME: \"pytorch\",\n",
     "            client.repository.DefinitionMetaNames.FRAMEWORK_VERSION: \"0.4\",\n",
     "            client.repository.DefinitionMetaNames.RUNTIME_NAME: \"python\",\n",
-    "            client.repository.DefinitionMetaNames.RUNTIME_VERSION: \"3.5\",\n",
+    "            client.repository.DefinitionMetaNames.RUNTIME_VERSION: \"3.6\",\n",
     "            client.repository.DefinitionMetaNames.EXECUTION_COMMAND: \"python3 main.py --epochs 1 --data-dir $DATA_DIR --result-dir $RESULT_DIR\"\n",
     "            }"
    ]


### PR DESCRIPTION
The notebook comes with Python 3.5 but it does not work. It needs to be set to 3.6.

The notebook does not use the processed directory.

The notebook tries to download torch 0.4.1 but that does not exist so changed to 0.4.0.
